### PR TITLE
Fix lsdiff for context diff hunks with elided after-images

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -223,7 +223,6 @@ TESTS = tests/newline1/run-test \
 # These ones don't work yet.
 # Feel free to send me patches. :-)
 XFAIL_TESTS = \
-	tests/lscontext3/run-test \
 	tests/delhunk5/run-test \
 	tests/delhunk6/run-test
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -160,6 +160,7 @@ TESTS = tests/newline1/run-test \
 	tests/nondiff1/run-test \
 	tests/lscontext1/run-test \
 	tests/lscontext2/run-test \
+	tests/lscontext3/run-test \
 	tests/filterp/run-test \
 	tests/select1/run-test \
 	tests/select2/run-test \
@@ -222,6 +223,7 @@ TESTS = tests/newline1/run-test \
 # These ones don't work yet.
 # Feel free to send me patches. :-)
 XFAIL_TESTS = \
+	tests/lscontext3/run-test \
 	tests/delhunk5/run-test \
 	tests/delhunk6/run-test
 

--- a/src/filterdiff.c
+++ b/src/filterdiff.c
@@ -759,9 +759,6 @@ do_context (FILE *f, char **header, unsigned int num_headers,
 			}
 		}
 
-		if (i && line_count == unchanged)
-			break;
-
 		got = getline (line, linelen, f);
 		if (got == -1) {
 			ret = EOF;
@@ -769,6 +766,9 @@ do_context (FILE *f, char **header, unsigned int num_headers,
 		}
 
 		++*linenum;
+
+		if (i && line_count == unchanged)
+			break;
 
 		while ((line_count == 0 && **line == '\\') ||
 		       line_count--) {

--- a/tests/lscontext3/run-test
+++ b/tests/lscontext3/run-test
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This is a lsdiff(1) testcase.
+
+
+. ${top_srcdir-.}/tests/common.sh
+
+printf 'a\n\n\n\n\n\n\n\nb\n' > file1.orig
+printf    '\n\n\n\n\n\n\n'    > file1
+${DIFF} -c file1.orig file1 > diff
+
+${LSDIFF} -nv diff 2>errors >index || exit 1
+[ -s errors ] && exit 1
+
+cat << EOF | cmp - index || exit 1
+1	file1
+	4	Hunk #1
+	11	Hunk #2
+EOF


### PR DESCRIPTION
Hello,

This pull request fixes an issue with lsdiff and filterdiff applied to context-style diffs.  When a hunk contains an elided post-image (when the change has only deletions, so the pre-image has only minus-lines and context lines, and post-image would only show the already-provided context) do_context fails to consume a line prior to continuing with the next hunk.

The first commit adds an xfail'ed testcase, and the second applies a proposed fix in do_context and un-xfails the test.