### PR TITLE
filterdiff: Display hunk comments containing NUL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -226,7 +226,6 @@ TESTS = tests/newline1/run-test \
 # These ones don't work yet.
 # Feel free to send me patches. :-)
 XFAIL_TESTS = \
-	tests/filterb/run-test \
 	tests/delhunk5/run-test \
 	tests/delhunk6/run-test
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,6 +162,7 @@ TESTS = tests/newline1/run-test \
 	tests/lscontext1/run-test \
 	tests/lscontext2/run-test \
 	tests/lscontext3/run-test \
+	tests/filterb/run-test \
 	tests/filterp/run-test \
 	tests/select1/run-test \
 	tests/select2/run-test \
@@ -225,6 +226,7 @@ TESTS = tests/newline1/run-test \
 # These ones don't work yet.
 # Feel free to send me patches. :-)
 XFAIL_TESTS = \
+	tests/filterb/run-test \
 	tests/delhunk5/run-test \
 	tests/delhunk6/run-test
 

--- a/src/filterdiff.c
+++ b/src/filterdiff.c
@@ -423,8 +423,13 @@ do_unified (FILE *f, char **header, unsigned int num_headers,
 							 " Hunk #%lu, %s",
 							 hunknum, bestname);
 
-					fputs (clean_comments ? "\n" : trailing,
-					       output_to);
+					if (clean_comments)
+						fputs ("\n", output_to);
+					else {
+						int idx = trailing - *line;
+						fwrite (trailing, (size_t) got-idx,
+							1, output_to);
+					}
 					break;
 				case Before:
 					// Note the initial line number

--- a/tests/filterb/run-test
+++ b/tests/filterb/run-test
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This is a filterdiff(1) testcase.
+# Test: Handle binary diff chunk headers
+
+
+. ${top_srcdir-.}/tests/common.sh
+
+/usr/bin/echo -ne "\
+--- a/file1
++++ b/file1
+@@ -1 +1,2 @@ The '\0' (NUL) character
+ a
++b
+" >diff
+
+${FILTERDIFF} diff 2>errors >filtered || exit 1
+[ -s errors ] && exit 1
+
+cmp diff filtered || exit 1


### PR DESCRIPTION
If the comment for a hunk contains an ASCII NUL, then no newline would be
output before the first line of context (as the c-string 'ended'
prematurely).  This breaks the patch such that it cannot be applied, even
with a fuzz factor.  Handle this unorthodox case to better support binary
files.

Included is a simplified test case showing the issue.