### PR TITLE
filterdiff: Fix header output.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -228,8 +228,7 @@ TESTS = tests/newline1/run-test \
 # Feel free to send me patches. :-)
 XFAIL_TESTS = \
 	tests/delhunk5/run-test \
-	tests/delhunk6/run-test \
-	tests/fullheader4/run-test
+	tests/delhunk6/run-test
 
 distclean-local:
 	-rm -rf $(top_builddir)/test-arena

--- a/tests/fullheader4/run-test
+++ b/tests/fullheader4/run-test
@@ -19,7 +19,7 @@ EOF
 ${FILTERDIFF} --strip=1 git-output 2>errors >output || { cat errors; exit 1; }
 [ -s errors ] && { cat errors; exit 1; }
 cmp output <<"EOF" || exit 1
-diff --git a/test.txt b/test.txt
+diff --git test.txt test.txt
 index 257cc56..5716ca5 100644
 --- test.txt
 +++ test.txt


### PR DESCRIPTION
When outputting header lines, apply prefix changes only to lines
starting with "---" and "+++" but also apply these changes to
arguments of a possibly diff command line.

Adapt tests/fullheader4/run-test and remove it from XFAIL_TESTS.

This fixes #12.