### PR TITLE
grepdiff: add `--only-match` option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -155,6 +155,8 @@ TESTS = tests/newline1/run-test \
 	tests/grepdiff5/run-test \
 	tests/grepdiff6/run-test \
 	tests/grepdiff7/run-test \
+	tests/grepdiff8/run-test \
+	tests/grepdiff9/run-test \
 	tests/number1/run-test \
 	tests/number2/run-test \
 	tests/number3/run-test \

--- a/doc/patchutils.xml
+++ b/doc/patchutils.xml
@@ -1803,6 +1803,7 @@ done)]]></screen></para>
 	    <arg>--no-filename</arg>
 	  </group>
 	  <arg choice="opt">--output-matching=<replaceable>WHAT</replaceable></arg>
+	  <arg choice="opt">--only-match=<replaceable>WHAT</replaceable></arg>
 	  <group choice="req">
 	    <arg><replaceable>REGEX</replaceable></arg>
 	    <arg>-f <replaceable>FILE</replaceable></arg>
@@ -2096,6 +2097,14 @@ done)]]></screen></para>
 	    <listitem>
 	      <para>Display the matching hunk-level or file-level
 	       diffs.</para>
+	    </listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+	    <term><option>--only-match</option>=rem|removals|add|additions|mod|modifications|all</term>
+	    <listitem>
+	      <para>Limit regex matching to removals, additions, modifications or
+            the whole hunk.</para>
 	    </listitem>
 	  </varlistentry>
 

--- a/tests/filterb/run-test
+++ b/tests/filterb/run-test
@@ -6,7 +6,7 @@
 
 . ${top_srcdir-.}/tests/common.sh
 
-/usr/bin/echo -ne "\
+printf "\
 --- a/file1
 +++ b/file1
 @@ -1 +1,2 @@ The '\0' (NUL) character

--- a/tests/flip1/run-test
+++ b/tests/flip1/run-test
@@ -29,7 +29,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip10/run-test
+++ b/tests/flip10/run-test
@@ -27,7 +27,7 @@ cat << EOF > patch2
 EOF
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip11/run-test
+++ b/tests/flip11/run-test
@@ -27,7 +27,7 @@ cat << EOF > patch2
 EOF
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip12/run-test
+++ b/tests/flip12/run-test
@@ -79,7 +79,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip13/run-test
+++ b/tests/flip13/run-test
@@ -87,7 +87,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip14/run-test
+++ b/tests/flip14/run-test
@@ -32,7 +32,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip15/run-test
+++ b/tests/flip15/run-test
@@ -27,7 +27,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip16/run-test
+++ b/tests/flip16/run-test
@@ -469,7 +469,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip17/run-test
+++ b/tests/flip17/run-test
@@ -29,7 +29,7 @@ cat << EOF > patch2
 EOF
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip18/run-test
+++ b/tests/flip18/run-test
@@ -38,7 +38,7 @@ cat << EOF > patch2
 EOF
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-flipped << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip2/run-test
+++ b/tests/flip2/run-test
@@ -29,7 +29,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip3/run-test
+++ b/tests/flip3/run-test
@@ -29,7 +29,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip4/run-test
+++ b/tests/flip4/run-test
@@ -53,7 +53,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip5/run-test
+++ b/tests/flip5/run-test
@@ -59,7 +59,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip6/run-test
+++ b/tests/flip6/run-test
@@ -63,7 +63,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip7/run-test
+++ b/tests/flip7/run-test
@@ -63,7 +63,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip8/run-test
+++ b/tests/flip8/run-test
@@ -109,7 +109,7 @@ EOF
 ${DIFF} -u file.orig file > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file.orig
 +++ file

--- a/tests/flip9/run-test
+++ b/tests/flip9/run-test
@@ -25,7 +25,7 @@ ${DIFF} -u file1.orig file1 > patch1
 ${DIFF} -u file2.orig file2 > patch2
 
 ${FLIPDIFF} patch1 patch2 > patch-flipped || exit 1
-sed -e "s/$(/bin/echo -ne '\t').*$//" patch-flipped > patch-cmp
+sed -e "s/$(printf '\t').*$//" patch-flipped > patch-cmp
 cmp - patch-cmp << EOF || exit 1
 --- file2.orig
 +++ file2

--- a/tests/grepdiff8/run-test
+++ b/tests/grepdiff8/run-test
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# This is a grepdiff(1) testcase.
+
+
+. ${top_srcdir-.}/tests/common.sh
+
+cat << EOF > diff
+--- file1
++++ file1
+@@ -1,2 +1,2 @@
+ context
+-a
++b
+--- file2
++++ file2
+@@ -1 +1 @@
+-bx
++a
+EOF
+
+${GREPDIFF} --only-match=rem 'a' diff 2>errors >rem || exit 1
+${GREPDIFF} --only-match=add 'a' diff 2>>errors >add || exit 1
+${GREPDIFF} --only-match=mod 'x' diff 2>>errors >mod || exit 1
+${GREPDIFF} --only-match=all 'x' diff 2>>errors >all || exit 1
+
+[ -s errors ] && exit 1
+
+cat << EOF | cmp - rem || exit 1
+file1
+EOF
+
+cat << EOF | cmp - add || exit 1
+file2
+EOF
+
+cat << EOF | cmp - mod || exit 1
+file2
+EOF
+
+cat << EOF | cmp - all || exit 1
+file1
+file2
+EOF

--- a/tests/grepdiff9/run-test
+++ b/tests/grepdiff9/run-test
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This is a grepdiff(1) testcase.
+
+
+. ${top_srcdir-.}/tests/common.sh
+
+cat << EOF > diff
+*** file1
+--- file1
+***************
+*** 1,2 ****
+  context
+- a
+--- 1,2 ----
+  context
++ b
+*** file2
+--- file2
+***************
+*** 1 ****
+- bx
+--- 1 ----
++ a
+EOF
+
+${GREPDIFF} --only-match=rem 'a' diff 2>errors >rem || exit 1
+${GREPDIFF} --only-match=add 'a' diff 2>>errors >add || exit 1
+${GREPDIFF} --only-match=mod 'x' diff 2>>errors >mod || exit 1
+${GREPDIFF} --only-match=all 'x' diff 2>>errors >all || exit 1
+
+[ -s errors ] && exit 1
+
+cat << EOF | cmp - rem || exit 1
+file1
+EOF
+
+cat << EOF | cmp - add || exit 1
+file2
+EOF
+
+cat << EOF | cmp - mod || exit 1
+file2
+EOF
+
+cat << EOF | cmp - all || exit 1
+file1
+file2
+EOF


### PR DESCRIPTION
This option allows to only apply regex filtering on removals, additions,
modifications, or the whole hunk.

Closes #3 

Still missing:
 - [x] update man page
 - [x] write tests