### PR TITLE
Add support for Windows CRLF line endings in patch processing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -228,7 +228,8 @@ TESTS = tests/newline1/run-test \
 	tests/fullheader2/run-test \
 	tests/fullheader3/run-test \
 	tests/fullheader4/run-test \
-	tests/whitespace/run-test
+	tests/whitespace/run-test \
+	tests/crlf/run-test
 
 # These ones don't work yet.
 # Feel free to send me patches. :-)

--- a/src/diff.c
+++ b/src/diff.c
@@ -1092,7 +1092,7 @@ read_timestamp (const char *timestamp, struct tm *result, long *zone)
 char *
 filename_from_header (const char *header)
 {
-	int first_space = strcspn (header, " \t\n");
+	int first_space = strcspn (header, " \t\n\r");
 	int h = first_space;
 	while (header[h] == ' ') {
 		int i;
@@ -1102,10 +1102,10 @@ filename_from_header (const char *header)
 		if (!read_timestamp (header + h + i, NULL, NULL))
 			break;
 		h += i + 1;
-		h += strcspn (header + h, " \t\n");
+		h += strcspn (header + h, " \t\n\r");
 	}
 
-	if (header[h] == '\n' && h > first_space)
+	if ((header[h] == '\n' || header[h] == '\r') && h > first_space)
 		/* If we couldn't see a date we recognized, but did see
 		   at least one space, split at the first. */
 		h = first_space;

--- a/tests/crlf/run-test
+++ b/tests/crlf/run-test
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# This is a test case for handling CRLF line endings in filenames
+# Test: Ensure lsdiff and filterdiff correctly handle CRLF in filenames and headers
+
+. ${top_srcdir-.}/tests/common.sh
+
+# Create some patches for adding and removing file cases
+cat <<"EOF" > create.patch
+diff --git a/test.txt b/test.txt
+new file mode 100644
+index 0000000..257cc56
+--- /dev/null
++++ b/test.txt
+@@ -0,0 +1 @@
++foo
+diff --git a/a/b/c/test_indir.txt b/a/test_indir.txt
+new file mode 100644
+index 0000000..257cc56
+--- /dev/null
++++ b/a/test_indir.txt
+@@ -0,0 +1 @@
++foo
+EOF
+
+cat <<"EOF" > remove.patch
+diff --git a/test.txt b/test.txt
+deleted file mode 100644
+index 257cc56..0000000
+--- a/test.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-foo
+diff --git a/a/b/c/test_indir.txt b/a/b/c/test_indir.txt
+deleted file mode 100644
+index 257cc56..0000000
+--- a/a/b/c/test_indir.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-foo
+EOF
+
+# Convert these patches to use CRLF line endings
+sed 's/$/\r/' create.patch > create.patch.crlf
+mv create.patch.crlf create.patch
+
+sed 's/$/\r/' remove.patch > remove.patch.crlf
+mv remove.patch.crlf remove.patch
+
+# Verify test.txt is in the lsdiff output
+${LSDIFF} create.patch > created_file 2>errors || exit 1
+[ -s errors ] && exit 1
+grep -F "test.txt" created_file || exit 1
+grep -F "test_indir.txt" created_file || exit 1
+
+${LSDIFF} remove.patch > removed_file 2>errors || exit 1
+[ -s errors ] && exit 1
+grep -F "test.txt" removed_file || exit 1
+grep -F "test_indir.txt" removed_file || exit 1
+
+# Verify the diff remains after filtering
+${FILTERDIFF} --include="*test*" create.patch > create_filter.patch 2>errors || exit 1
+[ -s errors ] && exit 1
+grep -F "test.txt" create_filter.patch || exit 1
+grep -F "test_indir.txt" create_filter.patch || exit 1
+
+${FILTERDIFF} --include="*test*" remove.patch > remove_filter.patch 2>errors || exit 1
+[ -s errors ] && exit 1
+grep -F "test.txt" remove_filter.patch || exit 1
+grep -F "test_indir.txt" remove_filter.patch || exit 1
+
+exit 0

--- a/tests/splitdiffD/run-test
+++ b/tests/splitdiffD/run-test
@@ -3,6 +3,8 @@
 # This is a splitdiff(1) testcase.
 # Test: See if -D works.
 
+# Set LC_ALL to avoid perl locale warnings
+export LC_ALL=C
 
 . ${top_srcdir-.}/tests/common.sh
 


### PR DESCRIPTION
This PR adds support for Windows-style CRLF line endings in patch files.

The changes include:
1. Fix locale settings in splitdiffD test to ensure stable test environment
2. Add comprehensive test cases for CRLF handling in patch files
3. Implement CRLF support in patch header filename parsing

The main issue was that the code didn't properly handle Windows-style 
CRLF line endings when parsing patch headers, which could lead to 
incorrect filename extraction.

Test Plan:
- All existing tests pass with the locale fix
- New CRLF tests verify both file addition and removal scenarios
- Tested with both LF and CRLF line endings