### PR TITLE
Symlink completions to an existing command (#93)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,11 +75,11 @@ install-exec-hook:
 install-data-hook:
 	if [ -d "$(DESTDIR)$(bashcompletiondir)" ]; then \
 		cd "$(DESTDIR)$(bashcompletiondir)" && \
-		mv bash-completion-patchutils patchutils && \
-		for cmd in filterdiff lsdiff grepdiff interdiff combinediff flipdiff rediff \
+		mv bash-completion-patchutils interdiff && \
+		for cmd in filterdiff lsdiff grepdiff combinediff flipdiff rediff \
 		           splitdiff recountdiff unwrapdiff dehtmldiff editdiff espdiff \
 		           fixcvsdiff patchview gitdiff svndiff gitdiffview svndiffview; do \
-			ln -sf patchutils "$$cmd" || true; \
+			ln -sf interdiff "$$cmd" || true; \
 		done; \
 	fi
 


### PR DESCRIPTION
Pick interdiff as main file and symlink all others to it.
Fixes: #93 
