### PR TITLE
Make grepdiff1 test-case pcre-aware

### DIFF
--- a/tests/grepdiff1/run-test
+++ b/tests/grepdiff1/run-test
@@ -20,7 +20,16 @@ cat << EOF > diff
 +b
 EOF
 
-${GREPDIFF} '\+a' diff 2>errors >index || exit 1
+# Check if PCRE2 is being used by examining the help output
+if ${GREPDIFF} --help 2>&1 | grep -q "PCRE regexes are used by default"; then
+    # PCRE2 is enabled - need to escape the plus sign
+    PATTERN='\+a'
+else
+    # Standard regex - plus sign doesn't need escaping
+    PATTERN='+a'
+fi
+
+${GREPDIFF} "$PATTERN" diff 2>errors >index || exit 1
 [ -s errors ] && exit 1
 
 cat << EOF | cmp - index || exit 1


### PR DESCRIPTION
The test case needs a different pattern when configured with/without pcre2.

Fixed: #61

Assisted-by: Cursor