### PR TITLE
Don't use gnulib getopt if we can avoid it

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -20,15 +20,6 @@
 /filename.h
 /fstat.c
 /getdtablesize.c
-/getopt-cdefs.in.h
-/getopt-core.h
-/getopt-ext.h
-/getopt-pfx-core.h
-/getopt-pfx-ext.h
-/getopt.c
-/getopt.in.h
-/getopt1.c
-/getopt_int.h
 /getprogname.c
 /getprogname.h
 /gettext.h
@@ -73,3 +64,7 @@
 /xalloc-oversized.h
 /getdelim.c
 /getline.c
+/fseterr.c
+/fseterr.h
+/stdio-consolesafe.c
+/stdio-impl.h

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -19,7 +19,6 @@
 /fcntl_h.m4
 /fstat.m4
 /getdtablesize.m4
-/getopt.m4
 /getprogname.m4
 /gnulib-common.m4
 /gnulib-comp.m4
@@ -38,7 +37,6 @@
 /msvc-nothrow.m4
 /multiarch.m4
 /musl.m4
-/nocrash.m4
 /off64_t.m4
 /off_t.m4
 /open-cloexec.m4
@@ -57,7 +55,6 @@
 /stdlib_h.m4
 /strerror.m4
 /string_h.m4
-/sys_cdefs_h.m4
 /sys_socket_h.m4
 /sys_stat_h.m4
 /sys_types_h.m4
@@ -69,3 +66,5 @@
 /zzgnulib.m4
 /getdelim.m4
 /getline.m4
+/fseterr.m4
+/gettext_h.m4

--- a/m4/gnulib-cache.m4
+++ b/m4/gnulib-cache.m4
@@ -38,15 +38,13 @@
 #  --no-libtool \
 #  --macro-prefix=gl \
 #  error \
-#  getline \
-#  getopt-gnu
+#  getline
 
 # Specification in the form of a few gnulib-tool.m4 macro invocations:
 gl_LOCAL_DIR([])
 gl_MODULES([
   error
   getline
-  getopt-gnu
 ])
 gl_AVOID([])
 gl_SOURCE_BASE([lib])


### PR DESCRIPTION
I get build failures on Fedora 42 otherwise.