### PR TITLE
lsdiff: fix output with --git-prefixes=strip --addprefix=...

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1090,7 +1090,7 @@ read_timestamp (const char *timestamp, struct tm *result, long *zone)
 }
 
 /* Helper function to strip Git a/ or b/ prefixes from a filename */
-static char *
+char *
 strip_git_prefix_from_filename (const char *filename, enum git_prefix_mode prefix_mode)
 {
 	if (prefix_mode == GIT_PREFIX_STRIP &&

--- a/src/diff.h
+++ b/src/diff.h
@@ -72,6 +72,7 @@ enum git_prefix_mode {
 
 char *filename_from_header (const char *header);
 char *filename_from_header_with_git_prefix_mode (const char *header, enum git_prefix_mode prefix_mode);
+char *strip_git_prefix_from_filename (const char *filename, enum git_prefix_mode prefix_mode);
 
 enum git_diff_type detect_git_diff_type (char **headers, unsigned int num_headers);
 int extract_git_filenames (char **headers, unsigned int num_headers,

--- a/src/filterdiff.c
+++ b/src/filterdiff.c
@@ -273,6 +273,9 @@ file_matches (void)
 static void display_filename (unsigned long linenum, char status,
 			      const char *filename, const char *patchname)
 {
+	const char *processed_filename;
+	char *git_stripped_filename = NULL;
+
 	if (mode == mode_list && !file_matches ())
 		/* This is lsdiff --files=... and this file is not to be
 		 * listed. */
@@ -288,7 +291,15 @@ static void display_filename (unsigned long linenum, char status,
 		printf ("%c ", status);
 	if (prefix_to_add)
 		fputs (prefix_to_add, stdout);
-	puts (stripped (filename, strip_components));
+
+	/* Handle git prefix stripping if needed */
+	git_stripped_filename = strip_git_prefix_from_filename(filename, git_prefix_mode);
+	processed_filename = stripped(git_stripped_filename, strip_components);
+
+	puts (processed_filename);
+
+	/* Clean up allocated memory */
+	free (git_stripped_filename);
 }
 
 static int


### PR DESCRIPTION
Assisted-by: Cursor