### PR TITLE
Wrapper fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,12 +14,7 @@ bin_SCRIPTS = \
 	scripts/espdiff
 
 dist_bin_SCRIPTS = \
-	patchview/gitdiff \
-	patchview/gitdiffview \
-	patchview/gitshow \
-	patchview/gitshowview \
-	patchview/svndiff \
-	patchview/svndiffview
+	patchview/patchview-wrapper$(EXEEXT)
 
 # Bash completion files
 bashcompletiondir = $(datadir)/bash-completion/completions
@@ -56,27 +51,46 @@ endif
 
 # Special rules for combinediff, flipdiff, lsdiff, grepdiff and patchview, which are
 # just symlinks.
-src/combinediff$(EXEEXT): src/interdiff$(EXEEXT)
+
+interdiff_links = \
+	src/combinediff$(EXEEXT) \
+	src/flipdiff$(EXEEXT)
+
+filterdiff_links = \
+	src/lsdiff$(EXEEXT) \
+	src/grepdiff$(EXEEXT) \
+	src/patchview$(EXEEXT)
+
+patchview_links = \
+	patchview/gitdiff$(EXEEXT) \
+	patchview/gitdiffview$(EXEEXT) \
+	patchview/gitshow$(EXEEXT) \
+	patchview/gitshowview$(EXEEXT) \
+	patchview/svndiff$(EXEEXT) \
+	patchview/svndiffview$(EXEEXT)
+
+$(interdiff_links): src/interdiff$(EXEEXT)
 	ln -sf $(notdir $<) $@
 
-src/flipdiff$(EXEEXT): src/interdiff$(EXEEXT)
+$(filterdiff_links): src/filterdiff$(EXEEXT)
 	ln -sf $(notdir $<) $@
 
-src/lsdiff$(EXEEXT): src/filterdiff$(EXEEXT)
-	ln -sf $(notdir $<) $@
-
-src/grepdiff$(EXEEXT): src/filterdiff$(EXEEXT)
-	ln -sf $(notdir $<) $@
-
-src/patchview$(EXEEXT): src/filterdiff$(EXEEXT)
+$(patchview_links): patchview/patchview-wrapper$(EXEEXT)
 	ln -sf $(notdir $<) $@
 
 install-exec-hook:
-	ln -sf "`echo interdiff|sed '$(transform)'`" $(DESTDIR)$(bindir)/"`echo combinediff|sed '$(transform)'`"
-	ln -sf "`echo interdiff|sed '$(transform)'`" $(DESTDIR)$(bindir)/"`echo flipdiff|sed '$(transform)'`"
-	ln -sf "`echo filterdiff|sed '$(transform)'`" $(DESTDIR)$(bindir)/"`echo lsdiff|sed '$(transform)'`"
-	ln -sf "`echo filterdiff|sed '$(transform)'`" $(DESTDIR)$(bindir)/"`echo grepdiff|sed '$(transform)'`"
-	ln -sf "`echo filterdiff|sed '$(transform)'`" $(DESTDIR)$(bindir)/"`echo patchview|sed '$(transform)'`"
+	@for f in $(interdiff_links); do \
+	    ln -sf "`echo interdiff$(EXEEXT) | sed '$(transform)'`" \
+	             "$(DESTDIR)$(bindir)/`basename $$f | sed '$(transform)'`"; \
+	done
+	@for f in $(filterdiff_links); do \
+	    ln -sf "`echo filterdiff$(EXEEXT) | sed '$(transform)'`" \
+	             "$(DESTDIR)$(bindir)/`basename $$f | sed '$(transform)'`"; \
+	done
+	@for f in $(patchview_links); do \
+	    ln -sf "`echo patchview-wrapper$(EXEEXT) | sed '$(transform)'`" \
+	             "$(DESTDIR)$(bindir)/`basename $$f | sed '$(transform)'`"; \
+	done
 
 install-data-hook:
 	if [ -d "$(DESTDIR)$(bashcompletiondir)" ]; then \
@@ -89,12 +103,16 @@ install-data-hook:
 		done; \
 	fi
 
-uninstall-hook:
-	rm -f $(DESTDIR)$(bindir)/"`echo combinediff|sed '$(transform)'`"
-	rm -f $(DESTDIR)$(bindir)/"`echo flipdiff|sed '$(transform)'`"
-	rm -f $(DESTDIR)$(bindir)/"`echo lsdiff|sed '$(transform)'`"
-	rm -f $(DESTDIR)$(bindir)/"`echo grepdiff|sed '$(transform)'`"
-	rm -f $(DESTDIR)$(bindir)/"`echo patchview|sed '$(transform)'`"
+uninstall-local:
+	@for f in $(interdiff_links); do \
+	    rm -f "$(DESTDIR)$(bindir)/`basename $$f | sed '$(transform)'`"; \
+	done
+	@for f in $(filterdiff_links); do \
+	    rm -f "$(DESTDIR)$(bindir)/`basename $$f | sed '$(transform)'`"; \
+	done
+	@for f in $(patchview_links); do \
+	    rm -f "$(DESTDIR)$(bindir)/`basename $$f | sed '$(transform)'`"; \
+	done
 	if [ -d "$(DESTDIR)$(bashcompletiondir)" ]; then \
 		cd "$(DESTDIR)$(bashcompletiondir)" && \
 		for cmd in filterdiff lsdiff grepdiff interdiff combinediff flipdiff rediff \
@@ -105,7 +123,7 @@ uninstall-hook:
 		rm -f patchutils; \
 	fi
 
-CLEANFILES=src/combinediff src/flipdiff src/lsdiff src/grepdiff src/patchview
+CLEANFILES = $(interdiff_links) $(filterdiff_links) $(patchview_links)
 MAINTAINERCLEANFILES=$(man_MANS)
 
 # Regression tests.

--- a/patchview/gitdiff
+++ b/patchview/gitdiff
@@ -1,1 +1,0 @@
-patchview-wrapper

--- a/patchview/gitdiffview
+++ b/patchview/gitdiffview
@@ -1,1 +1,0 @@
-patchview-wrapper

--- a/patchview/gitshow
+++ b/patchview/gitshow
@@ -1,1 +1,0 @@
-patchview-wrapper

--- a/patchview/gitshowview
+++ b/patchview/gitshowview
@@ -1,1 +1,0 @@
-patchview-wrapper

--- a/patchview/patchview-wrapper
+++ b/patchview/patchview-wrapper
@@ -22,6 +22,9 @@
 # "git show", "svn diff") piped into patchview, optionally also piped into
 # an editor
 
+# Note: gitdiff, gitdiffview, gitshow, gitshowview, svndiff, svndiffview
+# are symbolic links pointing to this wrapper.
+# They are automatically created by Makefile.am.
 
 import os
 import sys

--- a/patchview/svndiff
+++ b/patchview/svndiff
@@ -1,1 +1,0 @@
-patchview-wrapper

--- a/patchview/svndiffview
+++ b/patchview/svndiffview
@@ -1,1 +1,0 @@
-patchview-wrapper


### PR DESCRIPTION
* 315f146 Automatically generate symlinks for patchview-wrapper

    Instead of including them directly in the source code, this commit
    generates symlinks for gitdiff, gitdiffview, gitshow, gitshowview,
    svndiff, and svndiffview automatically via Makefile.am.

    Add install-exec-hook and uninstall-local to manage the symlinks,
    using loops to automatically create/remove them and avoid repetition
    of individual ln -sf and rm -f commands.

* 50b6ec5 With view we always use filterdiff, even if we don’t have any arguments.
