### PR TITLE
(#140) bugfix: Pipes are only done from stdout to stdin

### DIFF
--- a/patchview/patchview-wrapper
+++ b/patchview/patchview-wrapper
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
-# SPDX-License-Identifier: GPL-2.0-or-later
 # -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2015-2025 Sérgio Basto <sergio@serjux.com>
 #
@@ -54,60 +55,52 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-v', '--debug',
                     help='writes the commands that will be executed',
                     action='store_true')
-parser.add_argument('git_args', nargs='*', default=[])
+parser.add_argument('tool_args', nargs='*', default=[])
 parser.add_argument('patchview_args', nargs=argparse.REMAINDER)
 args, unknown = parser.parse_known_args()
-largs = vars(args).get("git_args")
-rargs = vars(args).get("patchview_args")
+tool_args = args.tool_args
+patchview_args = args.patchview_args + unknown
 
-patchview_cmd = ["patchview"] + rargs + unknown
-pipetoview = False
-if tool_cmd.endswith("view"):
-    # pipeline: first_pipe | second_pipe | editor
-    tool_cmd = tool_cmd[:-4]  # remove "view"
-    patchview_cmd = ["filterdiff"] + rargs + unknown
-    pipetoview = True
-git_cmd = [tool, tool_cmd] + largs
+pipetoview = tool_cmd.endswith("view")
+if pipetoview:
+    tool_cmd = tool_cmd[:-4]
+    patchview_cmd = ["filterdiff"] + patchview_args
+else:
+    patchview_cmd = ["patchview"] + patchview_args
 
-p1 = Popen(git_cmd, stdout=PIPE, env=enviro, cwd=workdir)
-p2 = Popen(patchview_cmd, stdin=p1.stdout, stdout=PIPE, env=enviro, cwd=workdir)
+vcs_cmd = [tool, tool_cmd] + tool_args
+dest_cmd = [editor, "-R", "-"]
+
+if args.debug:
+    debug_str = "%s | %s" % (" ".join(vcs_cmd), " ".join(patchview_cmd))
+    if pipetoview:
+        debug_str += " | %s" % " ".join(dest_cmd)
+    sys.stderr.buffer.write((debug_str + "\n").encode())
+    sys.stderr.flush()
+
+p1 = Popen(vcs_cmd, stdout=PIPE, env=enviro, cwd=workdir)
+if pipetoview:
+    p2 = Popen(patchview_cmd, stdin=p1.stdout, stdout=PIPE, env=enviro, cwd=workdir)
+else:
+    p2 = Popen(patchview_cmd, stdin=p1.stdout, env=enviro, cwd=workdir)
 
 p1.wait()
-stdout1, stderr1 = p1.communicate()
-if p1.returncode != 0:
+ret1 = p1.returncode
+if ret1 != 0:
+    stdout1, _ = p1.communicate()
     if stdout1:
         sys.stdout.buffer.write(stdout1)
-    if stderr1:
-        sys.stderr.buffer.write(stderr1)
-    sys.exit(p1.returncode)
+    sys.exit(ret1)
 
 p2.wait()
-stdout2, stderr2 = p2.communicate()
-if p2.returncode != 0:
+ret2 = p2.returncode
+if ret2 != 0:
+    stdout2, _ = p2.communicate()
     if stdout2:
         sys.stdout.buffer.write(stdout2)
-    if stderr2:
-        sys.stderr.buffer.write(stderr2)
-    sys.exit(p2.returncode)
+    sys.exit(ret2)
 
 if pipetoview:
-    dest_cmd = [editor, "-R", "-"]
-    p3 = Popen(dest_cmd, stdin=PIPE)
-    if args.debug:
-        debug_str = "%s | %s | %s\n" % (" ".join(git_cmd),
-                                     " ".join(patchview_cmd),
-                                     " ".join(dest_cmd))
-        p3.stdin.write(debug_str.encode())
-        p3.stdin.flush()
-
-    p3.stdin.write(stdout2)
-    p3.stdin.close()
+    p3 = Popen(dest_cmd, stdin=p2.stdout, env=enviro, cwd=workdir)
     p3.wait()
-else:
-    # debug print
-    if args.debug:
-        print("%s | %s" % (" ".join(git_cmd), " ".join(patchview_cmd)))
-        sys.stdout.flush()
-
-    sys.stdout.buffer.write(stdout2)
 


### PR DESCRIPTION
stderr does not belong in pipes

No mixing of wait() and communicate()

Either stdout goes directly to the terminal, or everything is captured

Each process writes to stdout

The next reads from stdin

The terminal or editor handles the rest

## Pull Request Guidelines

**Important**: Please note our branching strategy:
- `master` branch is for development towards 0.5.0
- `0.4.x` branch is for stable 0.4.x releases and bug fixes

**If you're submitting a bug fix for the stable release:**
- Target the `0.4.x` branch
- Bug fixes will be merged into `master` if needed

**If you're submitting a new feature:**
- Target the `master` branch

## Description
<!-- Describe your changes here -->

## Type of Change
- [x] Bug fix (targets 0.4.x)
- [ ] New feature (targets master)
- [ ] Documentation update
- [ ] Other (please describe)

## Testing
<!-- Describe how you tested your changes -->
