### PR TITLE
Add bash completions for gitshow and gitshowview

### DIFF
--- a/bash-completion-patchutils
+++ b/bash-completion-patchutils
@@ -452,3 +452,5 @@ complete -F _gitdiff gitdiff
 complete -F _svndiff svndiff
 complete -F _gitdiffview gitdiffview
 complete -F _svndiffview svndiffview
+complete -F _gitdiff gitshow
+complete -F _gitdiff gitshowview


### PR DESCRIPTION
The gitshow and gitshowview commands were added but were missing their bash completion registrations. They use the same completion function (_gitdiff) as gitdiff/gitdiffview since they accept the same filterdiff/patchview options.

Fixes: #139
