### PR TITLE
Fix installation of gitshow/gitshowview completion symlinks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,7 +179,8 @@ install-data-hook:
 		mv bash-completion-patchutils interdiff && \
 		for cmd in filterdiff lsdiff grepdiff combinediff flipdiff rediff \
 		           splitdiff recountdiff unwrapdiff dehtmldiff editdiff espdiff \
-		           fixcvsdiff patchview gitdiff svndiff gitdiffview svndiffview; do \
+		           fixcvsdiff patchview gitdiff svndiff gitdiffview svndiffview \
+		           gitshow gitshowview; do \
 			ln -sf interdiff "$$cmd" || true; \
 		done; \
 	fi
@@ -202,7 +203,8 @@ endif
 		cd "$(DESTDIR)$(bashcompletiondir)" && \
 		for cmd in filterdiff lsdiff grepdiff interdiff combinediff flipdiff rediff \
 		           splitdiff recountdiff unwrapdiff dehtmldiff editdiff espdiff \
-		           fixcvsdiff patchview gitdiff svndiff gitdiffview svndiffview; do \
+		           fixcvsdiff patchview gitdiff svndiff gitdiffview svndiffview \
+		           gitshow gitshowview; do \
 			rm -f "$$cmd"; \
 		done; \
 		rm -f patchutils; \


### PR DESCRIPTION
## Description
Fixes https://github.com/twaugh/patchutils/issues/174
Cleanly applies to both 0.4.x and master.

## Type of Change
- Bug fix (targets 0.4.x)

## Testing
Added patch to Gentoo packagae, installed & verified that gitshow/gitshowview bash completions now work as expected.
