### PR TITLE
flipdiff: Add option to fail loudly if patches don't commute

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -394,6 +394,8 @@ TESTS = tests/newline1/run-test \
 	tests/flip17/run-test \
 	tests/flip18/run-test \
 	tests/flip19/run-test \
+	tests/flip-err-no-commute1/run-test \
+	tests/flip-err-no-commute2/run-test \
 	tests/unline1/run-test \
 	tests/nul0/run-test \
 	tests/nul1/run-test \

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -68,3 +68,6 @@
 /fseterr.h
 /stdio-consolesafe.c
 /stdio-impl.h
+/memeq.c
+/stdcountof.in.h
+/streq.c

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -71,3 +71,6 @@
 /eealloc.m4
 /locale-fr.m4
 /wchar_t.m4
+/memeq.m4
+/stdcountof_h.m4
+/streq.m4

--- a/m4/gnulib-cache.m4
+++ b/m4/gnulib-cache.m4
@@ -1,4 +1,4 @@
-# Copyright (C) 2002-2025 Free Software Foundation, Inc.
+# Copyright (C) 2002-2026 Free Software Foundation, Inc.
 #
 # This file is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/interdiff.c
+++ b/src/interdiff.c
@@ -122,6 +122,7 @@ static int no_revert_omitted = 0;
 static int use_colors = 0;
 static int color_option_specified = 0;
 static int debug = 0;
+static int err_no_commute = 0;
 
 static struct patlist *pat_drop_context = NULL;
 
@@ -2260,7 +2261,10 @@ syntax (int err)
 "                  (interdiff) When a patch from patch1 is not in patch2,\n"
 "                  don't revert it\n"
 "  --in-place      (flipdiff) Write the output to the original input\n"
-"                  files\n";
+"                  files\n"
+"  --err-no-commute\n"
+"                  (flipdiff) If the patches don't commute, exit with an\n"
+"                  error\n";
 
 	fprintf (err ? stderr : stdout, syntax_str, progname, progname);
 	exit (err);
@@ -2333,6 +2337,7 @@ main (int argc, char *argv[])
 			{"color", 2, 0, 1000 + 'c'},
 			{"decompress", 0, 0, 'z'},
 			{"quiet", 0, 0, 'q'},
+			{"err-no-commute", 0, 0, 1000 + 'E'},
 			{0, 0, 0, 0}
 		};
 		char *end;
@@ -2411,6 +2416,9 @@ main (int argc, char *argv[])
 			break;
 		case 1000 + 'D':
 			debug = 1;
+			break;
+		case 1000 + 'E':
+			err_no_commute = 1;
 			break;
 		default:
 			syntax(1);

--- a/src/interdiff.c
+++ b/src/interdiff.c
@@ -2010,6 +2010,8 @@ flipdiff (FILE *p1, FILE *p2, FILE *flip1, FILE *flip2)
 				at += this_offset;
 				remove_line (&intermediate, line + 1, at);
 				this_offset--;
+			} else if (err_no_commute) {
+				error (EXIT_FAILURE, 0, "patches don't commute!");
 			}
 		} else if (line[0] == '-') {
 			if (!patch2_removes_line (linenum, offsets,
@@ -2020,6 +2022,8 @@ flipdiff (FILE *p1, FILE *p2, FILE *flip1, FILE *flip2)
 				at += this_offset;
 				insert_line (&intermediate, line + 1,
 					     (size_t) got - 1, at);
+			} else if (err_no_commute) {
+				error (EXIT_FAILURE, 0, "patches don't commute!");
 			}
 			this_offset++;
 		}

--- a/tests/flip-err-no-commute1/run-test
+++ b/tests/flip-err-no-commute1/run-test
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# This is a flipdiff(1) testcase.
+
+
+. ${top_srcdir-.}/tests/common.sh
+
+# Like flip15, but with --err-no-commute.
+# When a line is touched by both patches and --err-no-commute is passed,
+# we must quit with an error, and not make any changes.
+
+cat << EOF > file.orig
+int a;
+EOF
+
+cat << EOF > file
+int a, b;
+EOF
+
+${DIFF} -u file.orig file > patch1
+
+mv -f file file.orig
+cat << EOF > file
+ssize_t a, b;
+EOF
+
+${DIFF} -u file.orig file > patch2
+
+cp patch1 patch1.orig
+cp patch2 patch2.orig
+
+! ${FLIPDIFF} --err-no-commute patch1 patch2 > patch-flipped 2>errors || exit 1
+[ -s errors ] || exit 1
+! [ -s patch-flipped ] || exit 1
+
+exit 0

--- a/tests/flip-err-no-commute2/run-test
+++ b/tests/flip-err-no-commute2/run-test
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# This is a flipdiff(1) testcase.
+# Like flip1, but with --err-no-commute.
+# Test that we error because the patches don't commute.
+
+
+. ${top_srcdir-.}/tests/common.sh
+
+cat << EOF > file.orig
+a
+b
+c
+EOF
+
+cat << EOF > file
+a
+d
+c
+EOF
+
+${DIFF} -u file.orig file > patch1
+
+mv -f file file.orig
+cat << EOF > file
+a
+c
+EOF
+
+${DIFF} -u file.orig file > patch2
+
+! ${FLIPDIFF} --err-no-commute patch1 patch2 > patch-flipped 2>errors || exit 1
+[ -s errors ] || exit 1
+! [ -s patch-flipped ] || exit 1
+
+exit 0


### PR DESCRIPTION
## Pull Request Guidelines

Have been read and applied, this is a new feature and indeed targets `master`.

## Description

Adds a new option `--err-no-commute`.

If two patches don't commute because they modify the same lines, instead of putting the changes into the first patch, we error altogether.

This is useful whenever the integrity of the individual patches is in some way important, and failing loudly is preferable to possibly clobbering them.

I also have a concrete use case for this that I will put into a comment in order to keep the description brief.

## Type of Change

New feature

## Testing

I adapted two existing tests with non-commuting patches (`flip15` and `flip1`) to
- call the binary with the new option (`--err-no-commute`)
- make sure that this results in an error and an empty patch